### PR TITLE
Suppress JRuby 1.7.x 'warning: instance variable $variable not initializ...

### DIFF
--- a/lib/thread/pool.rb
+++ b/lib/thread/pool.rb
@@ -18,9 +18,13 @@ class Thread::Pool
 		attr_reader :pool, :timeout, :exception, :thread, :started_at
 
 		def initialize (pool, *args, &block)
-			@pool      = pool
-			@arguments = args
-			@block     = block
+			@pool       = pool
+			@arguments  = args
+			@block      = block
+			@running    = false
+			@finished   = false
+			@timedout   = false
+			@terminated = false
 		end
 
 		def running?;    @running;   end
@@ -221,7 +225,7 @@ class Thread::Pool
 	end
 
 	def wake_up_timeout
-		if @pipes
+		if defined? @pipes
 			@pipes.last.write_nonblock 'x' rescue nil
 		end
 	end


### PR DESCRIPTION
...ed'

JRuby 1.7.x complains about instance variables not being initialized:

.../threadpool-0.1.2/lib/threadpool.rb:30 warning: instance variable @terminated not initialized
.../threadpool-0.1.2/lib/threadpool.rb:27 warning: instance variable @running not initialized
.../threadpool-0.1.2/lib/threadpool.rb:28 warning: instance variable @finished not initialized
.../threadpool-0.1.2/lib/threadpool.rb:212 warning: instance variable @pipes not initialized

This change gets rid of these by initializing them upfront.
