### PR TITLE
Typo around calling :wake_up_timeout?

### DIFF
--- a/lib/thread/pool.rb
+++ b/lib/thread/pool.rb
@@ -50,7 +50,7 @@ class Thread::Pool
 			@running    = true
 			@started_at = Time.now
 
-			pool.__send__.wake_up_timeout
+			pool.__send__ :wake_up_timeout
 
 			begin
 				@block.call(*@arguments)


### PR DESCRIPTION
In lib/thread/pool.rb +53 the method 'wake_up_timeout' was called as a method on whatever **send** is supposed to return. This doesn't work in JRuby, nor am I sure if this works anywhere else. Could this be a simple typo?

Sorry for not putting this into a separate branch. Still not fully up on the git etiquette :) 
