### PR TITLE
Added args to #idle method

### DIFF
--- a/lib/thread/pool.rb
+++ b/lib/thread/pool.rb
@@ -207,7 +207,7 @@ class Thread::Pool
         end
 
         # Process Block when there is a idle worker if not block its returns
-        def idle (&block)
+        def idle (*args, &block)
                 while !idle?
                         @done_mutex.synchronize {
                                 break if idle?
@@ -219,7 +219,7 @@ class Thread::Pool
                         return
                 end
 
-                process &block
+                process *args, &block
 
         end
         


### PR DESCRIPTION
The `#idle` method did not support args so I added it.

BTW I saw this gem is not really in a proper format: gemspec is old, no Gemfile, weird spec tasks, mixed indentation, etc..
I would happily improve this for you in another pull request if you want ;)
