### PR TITLE
Added Thread::Pool.abort_on_exception attr_accessor.

### DIFF
--- a/lib/thread/pool.rb
+++ b/lib/thread/pool.rb
@@ -61,6 +61,7 @@ class Thread::Pool
 					return
 				else
 					@exception = reason
+					raise @exception if Thread::Pool.abort_on_exception
 				end
 			end
 
@@ -335,6 +336,13 @@ class Thread::Pool
 		}
 
 		self
+	end
+
+	@abort_on_exception = false
+	class << self
+		# If true, tasks will allow raised exceptions to pass through.
+		# Similar to Thread.abort_on_exception
+		attr_accessor :abort_on_exception
 	end
 
 	private


### PR DESCRIPTION
Often, in tests, it is helpful for debugging if exceptions raised in worker threads get passed up to abort the application.  Failing silently is not helpful to the debugging process.  For regular threads, we use `Thread.abort_on_exception = true` for this purpose.  Again, we don't do this in production, but it is very helpful when testing and debugging.

In this PR, I added a `Thread::Pool.abort_on_exception` attr_accessor.

If true, `Task`s will allow raised exceptions to pass through.
(Similar to Thread.abort_on_exception)