### PR TITLE
Fixed warning

### DIFF
--- a/lib/thread/pool.rb
+++ b/lib/thread/pool.rb
@@ -142,6 +142,7 @@ class Thread::Pool
 		@trim_requests = 0
 		@auto_trim     = false
 		@idle_trim     = nil
+		@timeout       = nil
 
 		@mutex.synchronize {
 			min.times {


### PR DESCRIPTION
Fixed "warning: instance variable @timeout not initialized" issued for pool.rb, line 324.
