### PR TITLE
lib/thread/future.rb: Remove the unusual space between the method nam…

### DIFF
--- a/lib/thread/future.rb
+++ b/lib/thread/future.rb
@@ -143,7 +143,7 @@ private
 		@cond ||= ConditionVariable.new
 	end
 
-	def deliver (value)
+	def deliver(value)
 		return if delivered?
 
 		@mutex.synchronize {


### PR DESCRIPTION
…e and its parameters to fix:

martind@paris:~/download/ruby-thread/lib$ ruby --version
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux-gnu]
martind@paris:~/download/ruby-thread/lib$ RUBYLIB=. ruby -we 'require "thread/future"'
/home/martind/download/ruby-thread/lib/thread/future.rb:146: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
martind@paris:~/download/ruby-thread/lib$ vim /home/martind/download/ruby-thread/lib/thread/future.rb +146
martind@paris:~/download/ruby-thread/lib$ RUBYLIB=. ruby -we 'require "thread/future"'
martind@paris:~/download/ruby-thread/lib$